### PR TITLE
Fix IPs for Private subnets

### DIFF
--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -385,9 +385,9 @@ Resources:
         pDMZSubnetBCIDR: 10.100.20.0/24
         pManagementCIDR: 10.10.0.0/16
         pAppPrivateSubnetACIDR: 10.100.96.0/21
-        pAppPrivateSubnetBCIDR: 10.100.119.0/21
-        pDBPrivateSubnetACIDR: 10.100.194.0/21
-        pDBPrivateSubnetBCIDR: 10.100.212.0/21
+        pAppPrivateSubnetBCIDR: 10.100.112.0/21
+        pDBPrivateSubnetACIDR: 10.100.192.0/21
+        pDBPrivateSubnetBCIDR: 10.100.208.0/21
         pVPCTenancy: !Ref VPCTenancy
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion


### PR DESCRIPTION
*Issue
CIDR for Privates Subnets B from Production VPC use the invalide CIDR. When we apply this cloudformation template, AWS automaticaly convert for right CIDR. So, because of this, the template and reality is diferent.

*Description of changes:
I change for corrects CIDR for these subnets.
This repository is included in quickstart-compliance-common repository, I pulled a request too for that repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
