### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/templates/centralized-logging-Additional_Account.yaml
+++ b/templates/centralized-logging-Additional_Account.yaml
@@ -166,7 +166,7 @@ Resources:
       Code:
         S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
         S3Key: !Sub ${QSS3KeyPrefix}functions/packages/cfnindexscript2/index.zip
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 300
 
   LogStreamerInvokePermission:

--- a/templates/centralized-logging-Primary_LCQS_Config_Alerts.yaml
+++ b/templates/centralized-logging-Primary_LCQS_Config_Alerts.yaml
@@ -432,7 +432,7 @@ Resources:
         Variables:
           LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 300
       Role: !GetAtt LambdaESCognitoRole.Arn
       Code:
@@ -937,7 +937,7 @@ Resources:
       Code:
         S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
         S3Key: !Sub ${QSS3KeyPrefix}functions/packages/logstreamer/index.zip
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 300
   LogStreamerInvokePermission:
     Type: AWS::Lambda::Permission

--- a/templates/database.template.yaml
+++ b/templates/database.template.yaml
@@ -179,7 +179,7 @@ Resources:
           # V56536055 - 10/08/2018 - better logging capabilities
           LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 300
       Role: !GetAtt ProcRole.Arn
       FunctionName: LambdaFirehoseProcessor


### PR DESCRIPTION
CloudFormation templates in quickstart-compliance-pci have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.